### PR TITLE
fix: The uniform names of texture samplers are incorrect

### DIFF
--- a/app/webgl-video-filter.js
+++ b/app/webgl-video-filter.js
@@ -198,11 +198,11 @@
         const gl = this.gl;
         const program = this.program;
         this.textureY = this._createTexture();
-        gl.uniform1i(gl.getUniformLocation(program, 'u_textureY'), 0);
+        gl.uniform1i(gl.getUniformLocation(program, 'u_samplerY'), 0);
 
         gl.activeTexture(gl.TEXTURE1);
         this.textureUV = this._createTexture();
-        gl.uniform1i(gl.getUniformLocation(program, 'u_textureUV'), 1);
+        gl.uniform1i(gl.getUniformLocation(program, 'u_samplerUV'), 1);
     }
 
     _compileShader(shaderSource, shaderType) {


### PR DESCRIPTION
The texture samplers are declared as `u_samplerY` and `u_samplerUV` in the shader code, but `u_textureY` and `u_textureUV` are used in JavaScript.

https://github.com/microsoft/teams-videoapp-sample/blob/0f4d507e43b484a3bb3b977658a61abfff8c1112/app/webgl-video-filter.js#L105-L106

https://github.com/microsoft/teams-videoapp-sample/blob/0f4d507e43b484a3bb3b977658a61abfff8c1112/app/webgl-video-filter.js#L201-L205