### PR TITLE
Update schema URL in manifest.json

### DIFF
--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.7/MicrosoftTeams.schema.json",
+  "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json",
   "manifestVersion": "devPreview",
   "version": "1.0.0",
   "id": "32cdab16-7c7c-40bc-94ac-c764e91d85a6",


### PR DESCRIPTION
With the outdated schema URL, this manifest can't pass the validation process of "Teams-Toolkit" VSCode extension.
Although we don't "support" the extension at the moment, it's good if we can minimize the gap as much as possible.
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/10903833/186697141-f2a34125-0816-4def-af03-53cd2127bae2.png)
